### PR TITLE
Instead of holding resources associated to a surface until the client…

### DIFF
--- a/src/compositor/compositor_api/qwaylandsurface.cpp
+++ b/src/compositor/compositor_api/qwaylandsurface.cpp
@@ -85,6 +85,9 @@ QWaylandSurface::QWaylandSurface(QWaylandSurfacePrivate *dptr)
 QWaylandSurface::~QWaylandSurface()
 {
     Q_D(QWaylandSurface);
+    foreach (QWaylandSurfaceInterface *iface, d->interfaces) {
+        iface->destroyResource();
+    }
     d->interfaces.clear();
     delete d->m_attacher;
 }

--- a/src/compositor/compositor_api/qwaylandsurfaceinterface.cpp
+++ b/src/compositor/compositor_api/qwaylandsurfaceinterface.cpp
@@ -54,14 +54,12 @@ QWaylandSurfaceInterface::QWaylandSurfaceInterface(QWaylandSurface *surface)
                    : d(new Private)
 {
     d->surface = surface;
-    d->surface->ref();
     surface->addInterface(this);
 }
 
 QWaylandSurfaceInterface::~QWaylandSurfaceInterface()
 {
     d->surface->removeInterface(this);
-    d->surface->destroy();
 }
 
 QWaylandSurface *QWaylandSurfaceInterface::surface() const

--- a/src/compositor/compositor_api/qwaylandsurfaceinterface.h
+++ b/src/compositor/compositor_api/qwaylandsurfaceinterface.h
@@ -114,6 +114,7 @@ protected:
     void setSurfaceClassName(const QString &name);
     void setSurfaceTitle(const QString &title);
 
+    virtual void destroyResource() = 0;
 private:
     class Private;
     Private *const d;

--- a/src/compositor/wayland_wrapper/qwlextendedsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlextendedsurface.cpp
@@ -112,6 +112,12 @@ bool ExtendedSurface::runOperation(QWaylandSurfaceOp *op)
     return false;
 }
 
+void ExtendedSurface::destroyResource()
+{
+   wl_resource_destroy(resource()->handle);  // this will trigger the destruction of the ExtendedSurface
+}
+
+
 void ExtendedSurface::extended_surface_update_generic_property(Resource *resource,
                                                                const QString &name,
                                                                struct wl_array *value)

--- a/src/compositor/wayland_wrapper/qwlextendedsurface_p.h
+++ b/src/compositor/wayland_wrapper/qwlextendedsurface_p.h
@@ -99,6 +99,7 @@ public:
 
 protected:
     bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+    void destroyResource() Q_DECL_OVERRIDE;
 
 private:
     Surface *m_surface;

--- a/src/compositor/wayland_wrapper/qwlshellsurface.cpp
+++ b/src/compositor/wayland_wrapper/qwlshellsurface.cpp
@@ -174,6 +174,11 @@ bool ShellSurface::runOperation(QWaylandSurfaceOp *op)
     return false;
 }
 
+void ShellSurface::destroyResource()
+{
+    wl_resource_destroy(resource()->handle);  // this will trigger the destruction of the ShellSurface
+}
+
 void ShellSurface::mapped()
 {
     if (m_surface->waylandSurface()->windowType() == QWaylandSurface::Popup) {

--- a/src/compositor/wayland_wrapper/qwlshellsurface_p.h
+++ b/src/compositor/wayland_wrapper/qwlshellsurface_p.h
@@ -104,6 +104,7 @@ public:
 
 protected:
     bool runOperation(QWaylandSurfaceOp *op) Q_DECL_OVERRIDE;
+    void destroyResource() Q_DECL_OVERRIDE;
 
 private Q_SLOTS:
     void mapped();


### PR DESCRIPTION
… is closed, do it as soon as the surface is destroyed.

This also follows the Wayland protocol, where a shell_surface should not outlive its associated surface.

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
