### PR TITLE
Fix destroy listener signal connection

### DIFF
--- a/src/hardwareintegration/compositor/wayland-egl/waylandeglclientbufferintegration.cpp
+++ b/src/hardwareintegration/compositor/wayland-egl/waylandeglclientbufferintegration.cpp
@@ -120,8 +120,6 @@ public:
         , gl_egl_image_target_texture_2d(0)
         , funcs(Q_NULLPTR)
     {
-        destroy_listener.d = this;
-        destroy_listener.listener.notify = destroy_listener_callback;
     }
 
     static void destroy_listener_callback(wl_listener *listener, void *data) {
@@ -131,6 +129,10 @@ public:
         buffer_destroy_listener *destroy_listener = reinterpret_cast<buffer_destroy_listener *>(listener);
         WaylandEglClientBufferIntegrationPrivate *self = destroy_listener->d;
         struct ::wl_resource *buffer = static_cast<struct ::wl_resource *>(data);
+
+        wl_list_remove(&listener->link);
+        delete listener;
+
         if (!self->buffers.contains(buffer))
             return;
 
@@ -146,11 +148,18 @@ public:
             self->funcs->destroy_stream(self->egl_display, state.egl_stream);
     }
 
+    void create_destroy_listener(struct ::wl_resource *buffer) {
+        buffer_destroy_listener *newListener = new buffer_destroy_listener;
+        newListener->d = this;
+        newListener->listener.notify = destroy_listener_callback;
+
+        wl_signal_add(&buffer->destroy_signal, &newListener->listener);
+    }
+
     EGLDisplay egl_display;
     bool valid;
     bool display_bound;
     QHash<struct ::wl_resource *, BufferState> buffers;
-    buffer_destroy_listener destroy_listener;
 
     PFNEGLBINDWAYLANDDISPLAYWL egl_bind_wayland_display;
     PFNEGLUNBINDWAYLANDDISPLAYWL egl_unbind_wayland_display;
@@ -260,7 +269,7 @@ void WaylandEglClientBufferIntegration::initialize(struct ::wl_resource *buffer)
     if (!buffer || d->buffers.contains(buffer))
         return;
 
-    wl_signal_add(&buffer->destroy_signal, &d->destroy_listener.listener);
+    d->create_destroy_listener(buffer);
 }
 
 GLenum WaylandEglClientBufferIntegration::textureTargetForBuffer(struct ::wl_resource *buffer) const


### PR DESCRIPTION
Remove it from the list in the callback, not when a new buffer
is created later on.

Change-Id: I2328edec9728752d18efaecede19eb4527d0f578
Reviewed-by: Louai Al-Khanji louai.al-khanji@theqtcompany.com
