### PR TITLE
qwaylandwindow: fix inputDevice for setPopup

### DIFF
--- a/src/client/qwaylandwindow.cpp
+++ b/src/client/qwaylandwindow.cpp
@@ -274,7 +274,7 @@ void QWaylandWindow::setVisible(bool visible)
                 if (parent) {
                     QWaylandWlShellSurface *wlshellSurface = qobject_cast<QWaylandWlShellSurface*>(mShellSurface);
                     if (wlshellSurface)
-                        wlshellSurface->setPopup(parent, mDisplay->lastInputDevice(), mDisplay->lastInputSerial());
+                        wlshellSurface->setPopup(parent, mDisplay->lastInputDevice()?:mDisplay->defaultInputDevice(), mDisplay->lastInputSerial());
                 }
             } else if (window()->type() == Qt::ToolTip) {
                 if (QWaylandWindow *parent = transientParent()) {


### PR DESCRIPTION
Use defaultInputDevice if there isn't any lastInputDevice

Signed-off-by: Christophe Chapuis chris.chapuis@gmail.com
